### PR TITLE
Escape markdown chars from IRC nicknames

### DIFF
--- a/ircc.py
+++ b/ircc.py
@@ -1,4 +1,5 @@
 import irc.bot
+import re
 
 # Based on irccat2.py and testbot.py from https://github.com/jaraco/irc
 
@@ -55,7 +56,9 @@ class IRC(irc.bot.SingleServerIRCBot):
     
     def on_pubmsg(self, connection, event):
         message = event.arguments[0].strip()
-        message = "%s: %s" % (event.source.nick, message)
+        message = "{:s} {:s}".format(\
+            re.sub(r"(]|-|\\|[`*_{}[()#+.!])", r'\\\1', event.source.nick), message)
+
         with self.thread_lock:
             print("[IRC] " + message)
         


### PR DESCRIPTION
When using nicknames like \`foo\` or \_bar\_ in IRC, Discord display them as `foo` or _bar_ markdown text. This avoid it to happen by escaping characters in the nickname message part.